### PR TITLE
Add type checking to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
           node-version: "20"
       - name: Install dependencies
         run: corepack enable && pnpm install
+      - name: Type Check
+        run: pnpm run typecheck
       - name: Build project
         run: pnpm run build
       - name: Generate version

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "type": "module",
   "scripts": {
     "build": "tsup src/main.ts --format esm --sourcemap",
-    "dev": "tsup src/main.ts --format esm --sourcemap --watch"
+    "dev": "tsup src/main.ts --format esm --sourcemap --watch",
+    "typecheck": "tsc"
   },
   "packageManager": "pnpm@9.1.1+sha256.9551e803dcb7a1839fdf5416153a844060c7bce013218ce823410532504ac10b",
   "bin": "./dist/main.js",


### PR DESCRIPTION
This pull request introduces type checking into the GitHub Actions workflow and updates the `package.json` script to support this new step.

- **GitHub Actions Workflow**: Adds a new step named "Type Check" that runs before the "Build project" step. This step executes `pnpm run typecheck` to perform TypeScript type checking.
- **Package.json Script**: Introduces a new script `"typecheck": "tsc"` to the `package.json` file, enabling the execution of the TypeScript compiler for type checking purposes.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eventpop/parallelizer?shareId=28fcd317-8501-4bd2-884f-300002d50bf2).